### PR TITLE
Web parser refactor

### DIFF
--- a/.github/workflows/django-test-stage.yaml
+++ b/.github/workflows/django-test-stage.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - src/**
       - requirements*.txt
+      - .github/workflows/**
 
 jobs:
   SAST:

--- a/.github/workflows/django-test-stage.yaml
+++ b/.github/workflows/django-test-stage.yaml
@@ -65,13 +65,11 @@ jobs:
         run: |
           echo ***Executing Django Tests***
           cd src/Clean-Energy-PA-Site/
-          python manage.py test
           coverage run manage.py test -v 2
           coverage report --fail-under=90
 
           echo ***Executing WebParser Tests***
           cd ../web_parser
-          pytest .
           coverage run -m pytest .
           coverage report --fail-under=90
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ PaPowerSwitch support application to help connect PA citizens with the best ener
 In addition, make sure to have a local copy of Postgres installed.
 
 You also should create a `.env` file in the `src/Clean-Energy-PA-Site/Website` directory, that includes the following variables with the values set:
-```
+
+```YAML
 SECRET_KEY=
 DB_USER=
 DB_PASSWORD=
@@ -37,21 +38,25 @@ CURRENT_DOMAIN=
 > First be sure your terminal is at the same directory as `manage.py`, which will be under `src/Clean-Energy-PA-Site` (the Django starting point)
 
 - Run server: `python manage.py runserver`
-- Run Tests: `python manage.py test`
-- Run coverage report:
-  - `coverage run manage.py test -v 2`
-  - `coverage report`
-  - `coverage html`
+- Run Tests (without coverage):
+  - `python manage.py test`
+- Run Tests (with coverage):
+  - `coverage run manage.py test`
+    - > Note: adding the `-v 2` flag will provide a verbose test output
+  - `coverage report` (generates report in terminal)
+  - `coverage html` (generates html version of report)
 
 ### Web Parser Commands
 
 > First change your terminal's directory to `src/web_parser`
 
-- Run Tests: `pytest .`
-- Run coverage report:
-  - `coverage run -m pytest .`
-  - `coverage report`
-  - `coverage html`
+- Run Tests (without coverage):
+  - `python -m pytest .`
+- Run Tests (with coverage):
+  - `coverage run pytest .`
+- Run Coverage Report
+  - `coverage report` (generates report in terminal)
+  - `coverage html` (generates html version of report)
 
 ## PyTest
 

--- a/src/Clean-Energy-PA-Site/EmailScheduler/contract_watch/contract_watchdog.py
+++ b/src/Clean-Energy-PA-Site/EmailScheduler/contract_watch/contract_watchdog.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 from GreenEnergySearch.models import User_Preferences
-from web_parser.papowerswitch_api import papowerswitch_api
-from web_parser.responses.ratesearch import price_structure
+from web_parser import papowerswitch_api, price_structure
 import pandas as pd
 from datetime import datetime, timedelta
 from EmailScheduler.views import build_offer_path_less_than_rate

--- a/src/Clean-Energy-PA-Site/EmailScheduler/price_watch/price_watchdog.py
+++ b/src/Clean-Energy-PA-Site/EmailScheduler/price_watch/price_watchdog.py
@@ -2,8 +2,7 @@ from django.contrib.auth.models import User
 from GreenEnergySearch.models import User_Preferences
 from EmailScheduler.views import build_offer_path_less_than_rate
 from django.urls import reverse
-from web_parser.papowerswitch_api import papowerswitch_api
-from web_parser.responses.ratesearch import price_structure
+from web_parser import papowerswitch_api, price_structure
 import pandas as pd
 
 api = papowerswitch_api()

--- a/src/Clean-Energy-PA-Site/EmailScheduler/tests/test_email_scheduler_base.py
+++ b/src/Clean-Energy-PA-Site/EmailScheduler/tests/test_email_scheduler_base.py
@@ -2,8 +2,7 @@ from Website.tests.test_base import BaseTest
 from unittest import mock
 
 from web_parser.tests import zipsearch_test_data, ratesearch_test_data
-from web_parser.responses.ratesearch import offer_collection
-from web_parser.responses.zipsearch import distributor_collection
+from web_parser import offer_collection, distributor_collection
 
 
 # Create your tests here.

--- a/src/Clean-Energy-PA-Site/EmailScheduler/tests/test_views.py
+++ b/src/Clean-Energy-PA-Site/EmailScheduler/tests/test_views.py
@@ -3,14 +3,13 @@ from ..views import build_offer_path_less_than_rate, offer_search_less_than_rate
 from bs4 import BeautifulSoup
 from unittest import mock
 from web_parser.tests import zipsearch_test_data, ratesearch_test_data
-from web_parser.responses.ratesearch import offer_collection
-from web_parser.responses.zipsearch import distributor_collection
+from web_parser import offer_collection, distributor_collection
 
 
 class Email_Scheduler_View_Test(EmailSchedulerBaseTest):
-    @mock.patch("web_parser.papowerswitch_api.papowerswitch_api.get_offers")
+    @mock.patch("web_parser.papowerswitch_api.get_offers")
     def test_offers_results(self, mock_get_offers):
-        # Mock the distributors reponse
+        # Mock the distributors reponses
         mock_get_offers.return_value = offer_collection(
             ratesearch_test_data.expected_example
         )

--- a/src/Clean-Energy-PA-Site/EmailScheduler/tests/test_views.py
+++ b/src/Clean-Energy-PA-Site/EmailScheduler/tests/test_views.py
@@ -9,7 +9,7 @@ from web_parser import offer_collection, distributor_collection
 class Email_Scheduler_View_Test(EmailSchedulerBaseTest):
     @mock.patch("web_parser.papowerswitch_api.get_offers")
     def test_offers_results(self, mock_get_offers):
-        # Mock the distributors reponses
+        # Mock the distributors reponse
         mock_get_offers.return_value = offer_collection(
             ratesearch_test_data.expected_example
         )

--- a/src/Clean-Energy-PA-Site/EmailScheduler/views.py
+++ b/src/Clean-Energy-PA-Site/EmailScheduler/views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import render, redirect
 from django.urls import reverse
-from web_parser.papowerswitch_api import papowerswitch_api
-from web_parser.responses.ratesearch import price_structure
+from web_parser import papowerswitch_api, price_structure
 
 
 # Create your views here.

--- a/src/Clean-Energy-PA-Site/GreenEnergySearch/forms.py
+++ b/src/Clean-Energy-PA-Site/GreenEnergySearch/forms.py
@@ -1,8 +1,0 @@
-from django import forms
-
-
-class RegisterUser(forms.Form):
-    name = forms.CharField(label="Name", max_length=80)
-    email = forms.CharField(label="Email", max_length=80, required=False)
-    username = forms.CharField(label="Username", max_length=80, required=False)
-    password = forms.CharField(label="Password", max_length=80, required=False)

--- a/src/Clean-Energy-PA-Site/GreenEnergySearch/models.py
+++ b/src/Clean-Energy-PA-Site/GreenEnergySearch/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
 
-from web_parser.responses.ratesearch import offer, offer_collection
+from web_parser import offer, offer_collection
 
 from datetime import date, datetime
 import json 
@@ -23,7 +23,7 @@ class possible_selections_obj:
         try:
             self.last_updated:datetime = datetime.fromisoformat(data["last_updated"])
             self.offers:offer_collection = offer_collection(data["offers"])
-        except:
+        except Exception:
             return False
 
     def dump(self):

--- a/src/Clean-Energy-PA-Site/GreenEnergySearch/tests/test_models.py
+++ b/src/Clean-Energy-PA-Site/GreenEnergySearch/tests/test_models.py
@@ -1,6 +1,6 @@
 from .test_green_energy_base import GreenEnergySearchBaseTest
 from web_parser.tests import ratesearch_test_data
-from web_parser.responses.ratesearch import offer
+from web_parser import offer
 import copy
 
 class TestModels(GreenEnergySearchBaseTest):

--- a/src/Clean-Energy-PA-Site/GreenEnergySearch/tests/test_views.py
+++ b/src/Clean-Energy-PA-Site/GreenEnergySearch/tests/test_views.py
@@ -1,7 +1,5 @@
 from .test_green_energy_base import GreenEnergySearchBaseTest
 from web_parser.tests import ratesearch_test_data
-from web_parser.responses.ratesearch import offer
-from GreenEnergySearch.models import User_Preferences
 import json
 import copy
 

--- a/src/Clean-Energy-PA-Site/GreenEnergySearch/tests/test_zip_search.py
+++ b/src/Clean-Energy-PA-Site/GreenEnergySearch/tests/test_zip_search.py
@@ -3,11 +3,10 @@ from GreenEnergySearch.views import build_zip_search_path, build_rate_type_path,
 from bs4 import BeautifulSoup
 from unittest import mock
 from web_parser.tests import zipsearch_test_data, ratesearch_test_data
-from web_parser.responses.ratesearch import offer_collection
-from web_parser.responses.zipsearch import distributor_collection
+from web_parser import offer_collection, distributor_collection
 
 class Zip_Search_View_Test(GreenEnergySearchBaseTest):
-    @mock.patch('web_parser.papowerswitch_api.papowerswitch_api.get_distributors')
+    @mock.patch('web_parser.papowerswitch_api.get_distributors')
     def test_distributors_selection(self, mock_get_distributors):
         """Test ID 59: Test verifies that the distributors are shown"""
 
@@ -29,7 +28,7 @@ class Zip_Search_View_Test(GreenEnergySearchBaseTest):
 
         self.assertEqual(len(element.findChildren()), 2)
 
-    @mock.patch('web_parser.papowerswitch_api.papowerswitch_api.get_distributors')
+    @mock.patch('web_parser.papowerswitch_api.get_distributors')
     def test_rateschedule_selection(self, mock_get_distributors):
         """Test ID 60: Test verifies that the rate schedules are shown"""
 
@@ -51,7 +50,7 @@ class Zip_Search_View_Test(GreenEnergySearchBaseTest):
 
         self.assertEqual(len(element.findChildren()), 2)
     
-    @mock.patch('web_parser.papowerswitch_api.papowerswitch_api.get_offers')
+    @mock.patch('web_parser.papowerswitch_api.get_offers')
     def test_offers_results(self, mock_get_offers):
         """Test ID 61: Test verifies that the offers are shown"""
 

--- a/src/Clean-Energy-PA-Site/GreenEnergySearch/views.py
+++ b/src/Clean-Energy-PA-Site/GreenEnergySearch/views.py
@@ -1,13 +1,11 @@
 from django.shortcuts import render, redirect
 from django.urls import reverse
-from web_parser.papowerswitch_api import papowerswitch_api
-from web_parser.responses.ratesearch import price_structure
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseForbidden, HttpResponse, JsonResponse
-from web_parser.responses.ratesearch import offer
 from GreenEnergySearch.models import User_Preferences
+from web_parser import offer, price_structure, papowerswitch_api
 import json
-from datetime import date, datetime
+from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 def build_zip_search_path(zipcode):
@@ -74,7 +72,7 @@ def offer_search(request, zipcode, distributor_id, rate_type):
         def sorter(val):
             return val.rate
         filtered_offers = offers.filter(renewable_energy=True,
-                                price_structure=price_structure.fixed,
+                                price_structure= price_structure.fixed,
                                 upper_rate=distributor_rate.rate + 0.05)
         filtered_offers.sort(key=sorter)
         return render(request, "GreenEnergySearch/offers.html", {"offers": filtered_offers,

--- a/src/web_parser/__init__.py
+++ b/src/web_parser/__init__.py
@@ -1,3 +1,7 @@
+from .papowerswitch_api import papowerswitch_api
+from .responses.ratesearch import offer, offer_collection, price_structure
+from .responses.zipsearch import distributor, distributor_collection
+
 import sys
 sys.path.append('.')
 sys.path.append('./tests')

--- a/src/web_parser/tests/test_papowerswitch_api.py
+++ b/src/web_parser/tests/test_papowerswitch_api.py
@@ -1,14 +1,10 @@
 #Need to append root to sys path
-from papowerswitch_api import papowerswitch_api
 import zipsearch_test_data
 import ratesearch_test_data
-import api_settings
 import requests_mock
 import requests
 import pytest
-from responses.ratesearch import offer_collection
-from responses.zipsearch import distributor_collection
-from responses.ratesearch import price_structure
+from .. import offer_collection, distributor_collection, price_structure, papowerswitch_api, api_settings
 
 class TestZipSearch:
 


### PR DESCRIPTION
- Changed web_parser to use the __init__.py to essentially export only the code that we want to expose. Simplifies web_parser api and simplifies mock calls.
- Removed unused "forms.py" in GreenEnergySearch